### PR TITLE
A failing test for slice

### DIFF
--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -242,6 +242,12 @@ sliceTests =
                 \n size ->
                     slice 0 n (initialize size identity)
                         |> Expect.equal (initialize (size + n) identity)
+            , fuzz defaultSizeRange "slicing all but the last item" <|
+              \size ->
+                initialize size identity
+                  |> slice (size-1) size
+                  |> toList
+                  |> Expect.equal [size-1]
             , test "both small" <|
                 \() ->
                     toList (slice 2 5 smallSample)


### PR DESCRIPTION
I found a bug and added a test for it. 

It occurs when slicing an array of 33 items from 32 to 33.

Unfortunately I'm not familiar enough with the implementation to fix it altogether.